### PR TITLE
We need root perms for everything in kickstart

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ My puppet code for configuring my Macs
 
 ```
 curl -sLo kickstart https://git.io/halyard
-bash kickstart
+sudo bash kickstart
 ```
 
 ## Usage


### PR DESCRIPTION
@akerl - Right? Most of what's in https://github.com/halyard/local-puppet-helper/blob/master/kickstart looks like it's going to need root 